### PR TITLE
Add filtering and pagination to RecordViewSet

### DIFF
--- a/records/views.py
+++ b/records/views.py
@@ -24,6 +24,7 @@ class StandardResultsSetPagination(LimitOffsetPagination):
                 description="Filter by record type (exact match).",
                 required=False,
                 type=OpenApiTypes.STR,
+                enum=["expense", "transfer", "income", "investment"],
                 location=OpenApiParameter.QUERY,
             ),
             OpenApiParameter(


### PR DESCRIPTION
This pull request significantly improves the `RecordViewSet` in `records/views.py` by adding advanced filtering, searching, and pagination capabilities, as well as enhancing API documentation. These changes make it easier for users to query records based on type and date, search by title or description, and receive paginated results.

**API enhancements:**

* Added query parameter filtering for `typeRecord`, exact `date`, `date_from`, and `date_to`, allowing users to retrieve records based on type and date ranges.
* Integrated `drf-spectacular` schema extensions to document the new query parameters in the API, improving discoverability for API consumers.

**Usability improvements:**

* Implemented pagination using a custom `StandardResultsSetPagination` class, with sensible defaults and limits.
* Enabled search functionality on `title` and `description` fields using Django REST Framework's `SearchFilter`.
* Updated queryset ordering to return the newest records first, providing a more user-friendly default sort order.