### PR TITLE
Refactor get_default_currency function to return the currency code in…

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 def get_default_currency():
     from currencies.models import Currency
 
-    return Currency.objects.get(code="COP")
+    return Currency.objects.get(code="COP").code
 
 
 class Account(models.Model):

--- a/records/models.py
+++ b/records/models.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 def get_default_currency():
     from currencies.models import Currency
 
-    return Currency.objects.get(code="COP")
+    return Currency.objects.get(code="COP").code
 
 
 class Record(models.Model):


### PR DESCRIPTION
This pull request makes a small change to the return value of the `get_default_currency` function in both the `accounts` and `records` apps. Instead of returning the entire `Currency` object, the functions now return just the currency code.

- Updated `get_default_currency` in `accounts/models.py` to return only the currency code instead of the full `Currency` object.
- Updated `get_default_currency` in `records/models.py` to return only the currency code instead of the full `Currency` object.…stead of the Currency object